### PR TITLE
Ip 4327 add queue.host entry to im/rabbitmq secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following table lists the configurable parameters of the amqp-pod-autoscaler
 | `podAnnotations` | pod annotations | {} |
 | `resources` | set resource limits | {} |
 | `amqp.managementUrl` | rabbitmq management url ex: http://rabbitmq-rabbitmq-ha.default.svc.cluster.local:15672 | nil |
+| `amqp.host` | rabbitmq host | nil |
 | `amqp.username` | rabbitmq username | nil |
 | `amqp.password` | rabbitmq password | nil |
 | `worker.deploymentLabel` | identifier label used for the worker deployment(s) | integration-manager-worker |

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -6,6 +6,7 @@ data:
   application.properties: |
     #AMQP
     queue.management-url={{ default "none" .Values.amqp.managementUrl }}
+    queue.host=${rabbitmq-host}
     queue.username=${rabbitmq-username}
     queue.password=${rabbitmq-password}
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
         secret:
           secretName: {{ .Values.existingRabbitSecret }}
           items:
+          - key: rabbitmq-host
+            path: rabbitmq-host
           - key: rabbitmq-username
             path: rabbitmq-username
           - key: rabbitmq-password

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -10,6 +10,7 @@ metadata:
 type: Opaque
 data:
   {{- if not .Values.existingRabbitSecret }}
+  rabbitmq-host: {{ (toString .Values.amqp.host) | b64enc }}
   rabbitmq-username: {{ (toString .Values.amqp.username) | b64enc }}
   rabbitmq-password: {{ (toString .Values.amqp.password) | b64enc }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -31,6 +31,7 @@ revisionHistoryLimit: 10
 existingAutoscalerSecret:
 existingRabbitSecret:
 # Must have the keys:
+#   rabbitmq-host
 #   rabbitmq-username
 #   rabbitmq-password
 replicaCount: 1
@@ -44,6 +45,7 @@ amqp:
 #  # Set managementUrl to http://rabbitmq-rabbitmq-ha.default.svc.cluster.local:15672 if using helm rabbitmq-ha
   managementUrl:
 #  # Set if not using existingRabbitSecret
+  host:
   username:
   password:
 worker:


### PR DESCRIPTION
Adding rabbitmq-host key to the existingRabbitSecret secret.
Adding queue.host to the configmap and passing rabbitmq-host value to it from the secrets.