### PR TITLE
Ip 4327 add port number

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -15,9 +15,6 @@ data:
     {{- if .Values.amqp.sslKeyStore }}
     queue.ssl.key-store={{ .Values.amqp.sslKeyStore }}
     {{- end}}
-    {{- if .Values.amqp.sslKeyStorePassword }}
-    queue.ssl.key-store-password={{ .Values.amqp.sslKeyStorePassword }}
-    {{- end}}
     queue.ssl.key-store-type={{ .Values.amqp.sslKeyStoreType }}
     queue.ssl.protocol={{ .Values.amqp.sslProtocol }}    
 

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -9,12 +9,20 @@ data:
     queue.host=${rabbitmq-host}
     queue.username=${rabbitmq-username}
     queue.password=${rabbitmq-password}
+    queue.port={{ .Values.amqp.port }}
+    queue.connectionTimeout={{ .Values.amqp.connectionTimeout }}
+    queue.ssl.enabled={{ .Values.amqp.sslEnabled }}
+    {{- if .Values.amqp.sslKeyStore }}
+    queue.ssl.key-store={{ .Values.amqp.sslKeyStore }}
+    {{- end}}
+    {{- if .Values.amqp.sslKeyStorePassword }}
+    queue.ssl.key-store-password={{ .Values.amqp.sslKeyStorePassword }}
+    {{- end}}
+    queue.ssl.key-store-type={{ .Values.amqp.sslKeyStoreType }}
+    queue.ssl.protocol={{ .Values.amqp.sslProtocol }}    
 
     worker.deployment.label={{ .Values.worker.deploymentLabel }}
     autoscale.monitoring.rate={{ .Values.autoscale.monitoringRate }}
-
-    # Integration Manager Configuration
-    actian.im.url={{ .Values.actian.im.url }}
 
     {{- if .Values.extraConfig }}
     {{ .Values.extraConfig | indent 4 | trim }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -14,5 +14,7 @@ data:
   rabbitmq-username: {{ (toString .Values.amqp.username) | b64enc }}
   rabbitmq-password: {{ (toString .Values.amqp.password) | b64enc }}
   {{- end }}
+  {{- if .Values.amqp.sslKeyStorePassword }}
+  ssl-key-store-password: {{ .Values.amqp.sslKeyStorePassword }}
+  {{- end}}
 {{- end }}
-

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -14,17 +14,5 @@ data:
   rabbitmq-username: {{ (toString .Values.amqp.username) | b64enc }}
   rabbitmq-password: {{ (toString .Values.amqp.password) | b64enc }}
   {{- end }}
-  {{- if .Values.actian.im.clientId }}
-  actian.im.client-id: {{ (toString .Values.actian.im.clientId) | b64enc }}
-  {{- end }}
-  {{- if .Values.actian.im.clientSecret }}
-  actian.im.client-secret: {{ (toString .Values.actian.im.clientSecret) | b64enc }}
-  {{- end }}
-  {{- if .Values.actian.im.deviceCode }}
-  actian.im.device-code: {{ (toString .Values.actian.im.deviceCode) | b64enc }}
-  {{- end }}
-  {{- if .Values.actian.im.userCode }}
-  actian.im.user-code: {{ (toString .Values.actian.im.userCode) | b64enc }}
-  {{- end }}
 {{- end }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -44,21 +44,20 @@ resources: {}
 amqp:
 #  # Set managementUrl to http://rabbitmq-rabbitmq-ha.default.svc.cluster.local:15672 if using helm rabbitmq-ha
   managementUrl:
-#  # Set if not using existingRabbitSecret
+#  # Set host, username & password if not using existingRabbitSecret
   host:
   username:
   password:
+  port: 5672
+  connectionTimeout: 20
+  sslEnabled: false
+  sslKeyStore: rabbitmq-security/keycert.p12
+  sslKeyStorePassword: changeit
+  sslKeyStoreType: PKCS12
+  sslProtocol: TLSv1.2
 worker:
   deploymentLabel: integration-manager-worker
 autoscale:
   monitoringRate: 30000
-## Actian Integration Manager connection parameters
-actian:
-  im:
-    url:
-    clientId:
-    clientSecret:
-    deviceCode:
-    userCode:
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -51,8 +51,8 @@ amqp:
   port: 5672
   connectionTimeout: 20
   sslEnabled: false
-  sslKeyStore: rabbitmq-security/keycert.p12
-  sslKeyStorePassword: changeit
+  sslKeyStore:
+  sslKeyStorePassword:
   sslKeyStoreType: PKCS12
   sslProtocol: TLSv1.2
 worker:


### PR DESCRIPTION
1) Adding additional amqp properties from https://alm.actian.com/bitbucket/projects/DF/repos/integration-manager-kubernetes/browse/amqp-pod-autoscaler/src/main/resources/application.properties
2) Removing Actian Integration Manager connection parameters because amqp-pod-autoscaler doesn't use IM API anymore and strictly uses amqp for messaging now.